### PR TITLE
Fix trivial compile errors

### DIFF
--- a/lib/deriver.ml
+++ b/lib/deriver.ml
@@ -94,7 +94,7 @@ module Located (A : Ast_builder.S) : S = struct
               >|= unlabelled
             in
             pexp_apply (pexp_ident lident) cons_args )
-    | Ptyp_variant (_, Open, _) -> Raise.unsupported_type_open_polyvar ~loc typ
+    | Ptyp_variant (_, Open, _) -> Raise.unsupported_type_polyvar ~loc typ
     (* | Ptyp_variant (rowfields, Closed, labellist) -> *)
     | Ptyp_poly _ -> Raise.unsupported_type_poly ~loc typ
     | Ptyp_tuple args ->

--- a/lib/raise.ml
+++ b/lib/raise.ml
@@ -38,3 +38,8 @@ let unsupported_type_package ~loc ctyp =
 let unsupported_type_extension ~loc ctyp =
   Location.raise_errorf ~loc "%s: unprocessed extension %a encountered." name
     Pprintast.core_type ctyp
+
+let unsupported_type_alias ~loc ctyp =
+  Location.raise_errorf ~loc
+    "%s: alias type %a encountered. Alias types are not supported."
+    name Pprintast.core_type ctyp


### PR DESCRIPTION
`master` fails to compile due to some trivial errors.