### PR TITLE
Force no error coloring in OCaml 4.08

### DIFF
--- a/test/deriver/errors/dune.inc
+++ b/test/deriver/errors/dune.inc
@@ -11,7 +11,7 @@
   (action
     (with-stderr-to
       %{targets}
-      (bash "./%{pp} -no-color --impl %{input} || true")
+      (bash "! OCAML_COLOR=false ./%{pp} -no-color --impl %{input}")
     )
   )
 )
@@ -33,7 +33,7 @@
   (action
     (with-stderr-to
       %{targets}
-      (bash "./%{pp} -no-color --impl %{input} || true")
+      (bash "! OCAML_COLOR=false ./%{pp} -no-color --impl %{input}")
     )
   )
 )
@@ -55,7 +55,7 @@
   (action
     (with-stderr-to
       %{targets}
-      (bash "./%{pp} -no-color --impl %{input} || true")
+      (bash "! OCAML_COLOR=false ./%{pp} -no-color --impl %{input}")
     )
   )
 )
@@ -77,7 +77,7 @@
   (action
     (with-stderr-to
       %{targets}
-      (bash "./%{pp} -no-color --impl %{input} || true")
+      (bash "! OCAML_COLOR=false ./%{pp} -no-color --impl %{input}")
     )
   )
 )
@@ -99,7 +99,7 @@
   (action
     (with-stderr-to
       %{targets}
-      (bash "./%{pp} -no-color --impl %{input} || true")
+      (bash "! OCAML_COLOR=false ./%{pp} -no-color --impl %{input}")
     )
   )
 )
@@ -121,7 +121,7 @@
   (action
     (with-stderr-to
       %{targets}
-      (bash "./%{pp} -no-color --impl %{input} || true")
+      (bash "! OCAML_COLOR=false ./%{pp} -no-color --impl %{input}")
     )
   )
 )
@@ -143,7 +143,7 @@
   (action
     (with-stderr-to
       %{targets}
-      (bash "./%{pp} -no-color --impl %{input} || true")
+      (bash "! OCAML_COLOR=false ./%{pp} -no-color --impl %{input}")
     )
   )
 )
@@ -165,7 +165,7 @@
   (action
     (with-stderr-to
       %{targets}
-      (bash "./%{pp} -no-color --impl %{input} || true")
+      (bash "! OCAML_COLOR=false ./%{pp} -no-color --impl %{input}")
     )
   )
 )

--- a/test/deriver/errors/gen_dune_rules.ml
+++ b/test/deriver/errors/gen_dune_rules.ml
@@ -14,7 +14,7 @@ let output_stanzas filename =
   (action
     (with-stderr-to
       %%{targets}
-      (bash "./%%{pp} -no-color --impl %%{input} || true")
+      (bash "! OCAML_COLOR=false ./%%{pp} -no-color --impl %%{input}")
     )
   )
 )

--- a/test/deriver/errors/unsupported_tuple_size.expected
+++ b/test/deriver/errors/unsupported_tuple_size.expected
@@ -1,4 +1,6 @@
-[1mFile "unsupported_tuple_size.ml", line 1, characters 0-53[0m:
+File "_none_", line 1:
+Warning 46: illegal environment variable OCAML_COLOR : expected "auto", "always" or "never"
+File "unsupported_tuple_size.ml", line 1, characters 0-53:
 1 | type t = unit * unit * unit * unit [@@deriving irmin]
-    [1;31m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
-[1;31mError[0m: ppx_irmin: tuple types must have 2 or 3 components. Found 4.
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: ppx_irmin: tuple types must have 2 or 3 components. Found 4.

--- a/test/deriver/errors/unsupported_type_arrow.expected
+++ b/test/deriver/errors/unsupported_type_arrow.expected
@@ -1,4 +1,6 @@
-[1mFile "unsupported_type_arrow.ml", line 1, characters 0-39[0m:
+File "_none_", line 1:
+Warning 46: illegal environment variable OCAML_COLOR : expected "auto", "always" or "never"
+File "unsupported_type_arrow.ml", line 1, characters 0-39:
 1 | type t = unit -> int [@@deriving irmin]
-    [1;31m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
-[1;31mError[0m: ppx_irmin: function type encountered: unit -> int. Functions are not Irmin-serialisable.
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: ppx_irmin: function type encountered: unit -> int. Functions are not Irmin-serialisable.

--- a/test/deriver/errors/unsupported_type_extension.expected
+++ b/test/deriver/errors/unsupported_type_extension.expected
@@ -1,4 +1,6 @@
-[1mFile "unsupported_type_extension.ml", line 1, characters 0-34[0m:
+File "_none_", line 1:
+Warning 46: illegal environment variable OCAML_COLOR : expected "auto", "always" or "never"
+File "unsupported_type_extension.ml", line 1, characters 0-34:
 1 | type t = [%typ] [@@deriving irmin]
-    [1;31m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
-[1;31mError[0m: ppx_irmin: unprocessed extension [%typ ] encountered.
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: ppx_irmin: unprocessed extension [%typ ] encountered.

--- a/test/deriver/errors/unsupported_type_open.expected
+++ b/test/deriver/errors/unsupported_type_open.expected
@@ -1,4 +1,6 @@
-[1mFile "unsupported_type_open.ml", line 1, characters 0-30[0m:
+File "_none_", line 1:
+Warning 46: illegal environment variable OCAML_COLOR : expected "auto", "always" or "never"
+File "unsupported_type_open.ml", line 1, characters 0-30:
 1 | type t = .. [@@deriving irmin]
-    [1;31m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
-[1;31mError[0m: ppx_irmin: extensible variant types are not Irmin-serialisable.
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: ppx_irmin: extensible variant types are not Irmin-serialisable.

--- a/test/deriver/errors/unsupported_type_package.expected
+++ b/test/deriver/errors/unsupported_type_package.expected
@@ -1,4 +1,6 @@
-[1mFile "unsupported_type_package.ml", line 5, characters 0-38[0m:
+File "_none_", line 1:
+Warning 46: illegal environment variable OCAML_COLOR : expected "auto", "always" or "never"
+File "unsupported_type_package.ml", line 5, characters 0-38:
 5 | type t = (module S) [@@deriving irmin]
-    [1;31m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
-[1;31mError[0m: ppx_irmin: package type (module S) encountered. Package types are not Irmin-serialisable.
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: ppx_irmin: package type (module S) encountered. Package types are not Irmin-serialisable.

--- a/test/deriver/errors/unsupported_type_poly.expected
+++ b/test/deriver/errors/unsupported_type_poly.expected
@@ -1,4 +1,6 @@
-[1mFile "unsupported_type_poly.ml", line 1, characters 0-42[0m:
+File "_none_", line 1:
+Warning 46: illegal environment variable OCAML_COLOR : expected "auto", "always" or "never"
+File "unsupported_type_poly.ml", line 1, characters 0-42:
 1 | type t = { v : 'a. 'a } [@@deriving irmin]
-    [1;31m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
-[1;31mError[0m: ppx_irmin: universally-quantified type 'a . 'a encountered. Irmin types must be grounded.
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: ppx_irmin: universally-quantified type 'a . 'a encountered. Irmin types must be grounded.

--- a/test/deriver/errors/unsupported_type_polyvariant.expected
+++ b/test/deriver/errors/unsupported_type_polyvariant.expected
@@ -1,4 +1,6 @@
-[1mFile "unsupported_type_polyvariant.ml", line 1, characters 0-42[0m:
+File "_none_", line 1:
+Warning 46: illegal environment variable OCAML_COLOR : expected "auto", "always" or "never"
+File "unsupported_type_polyvariant.ml", line 1, characters 0-42:
 1 | type t = [ `On | `Off ] [@@deriving irmin]
-    [1;31m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
-[1;31mError[0m: ppx_irmin: polymorphic variant [ `On  | `Off ] encountered. Polymorphic variants are not Irmin-serialisable.
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: ppx_irmin: polymorphic variant [ `On  | `Off ] encountered. Polymorphic variants are not Irmin-serialisable.

--- a/test/deriver/errors/unsupported_type_variable.expected
+++ b/test/deriver/errors/unsupported_type_variable.expected
@@ -1,4 +1,6 @@
-[1mFile "unsupported_type_variable.ml", line 1, characters 0-43[0m:
+File "_none_", line 1:
+Warning 46: illegal environment variable OCAML_COLOR : expected "auto", "always" or "never"
+File "unsupported_type_variable.ml", line 1, characters 0-43:
 1 | type 'typvar t = 'typvar [@@deriving irmin]
-    [1;31m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
-[1;31mError[0m: ppx_irmin: uninstantiated type variable 'typvar found. Irmin types must be grounded.
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: ppx_irmin: uninstantiated type variable 'typvar found. Irmin types must be grounded.


### PR DESCRIPTION
The `-no-color` option should prevent colours from being generated by the standalone Ppxlib deriver, but this seems to not be the case (see https://github.com/ocaml-ppx/ppxlib/pull/83).