### PR TITLE
Remove the 'build' directive on dune dependency

### DIFF
--- a/ppx_irmin.opam
+++ b/ppx_irmin.opam
@@ -15,7 +15,7 @@ run-test: [
 ]
 
 depends: [
-  "dune" {build}
+  "dune"
   "ocaml" {>= "4.06.0"}
   "ppxlib" {= "0.9.0"}
   "irmin"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.